### PR TITLE
Fix/alias vsts npm auth

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,13 @@
 
 This library was forked from [better-vsts-npm-auth](https://github.com/zumwald/better-vsts-npm-auth)
 
+## Using better-vsts-npm-auth as an Alias
+
+If you want to use `better-vsts-npm-auth` as an alias, then `better-vsts-npm-auth` must not be installed.
+```
+npm uninstall -g better-vsts-npm-auth
+```
+
 ## Installation
 
 While not necessary, _auto-vsts-npm-auth_ was built to be used as a global module.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "auto-vsts-npm-auth",
-  "version": "5.1.1",
+  "version": "5.1.2-alpha",
   "description": "Platform agnostic library which provides a robust solution for maintaining credentials in your npmrc files",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/package.json
+++ b/package.json
@@ -12,7 +12,8 @@
     "dist"
   ],
   "bin": {
-    "auto-vsts-npm-auth": "dist/cli.js"
+    "auto-vsts-npm-auth": "dist/cli.js",
+    "better-vsts-npm-auth": "dist/cli.js"
   },
   "scripts": {
     "ci": "yarn run build && yarn run test:ci",


### PR DESCRIPTION
I made alias `better-vsts-npm-auth` for `auto-vsts-npm-auth`.
(If you want to use `auto-vsts-npm-auth` with alias `better-vsts-npm-auth`, then you should uninstall `better-vsts-npm-auth`)